### PR TITLE
Improve generic packaging

### DIFF
--- a/eng/lib.sh
+++ b/eng/lib.sh
@@ -244,7 +244,7 @@ build() {
   dotnet restore --runtime "${NET_RUNTIME}" --verbosity quiet
 
   echo "Running dotnet clean..."
-  dotnet clean --runtime "${NET_RUNTIME}" --configuration "${CONFIG}" --verbosity quiet
+  dotnet clean --configuration "${CONFIG}" --verbosity quiet
 
   if [ "${PORTABLE}" = "true" ]; then
     mkdir -p "${OUTPUT}/userdata"
@@ -292,13 +292,13 @@ copy_manpage() {
   local output_folder="${1}"
 
   echo "Copying manpage(s) to '${output_folder}'..."
-  pushd "${REPO_ROOT}/docs/manpages"
+  pushd "${REPO_ROOT}/docs/manpages" > /dev/null
   for manpage in *; do
     local index="$(echo $manpage | rev | cut -d. -f1)"
     mkdir -p "${output_folder}/man${index}"
     gzip -c $manpage > "${output_folder}/man${index}/${manpage}.gz"
   done
-  popd
+  popd > /dev/null
 }
 
 create_source_tarball() {

--- a/eng/linux/BinaryTarBall/package.sh
+++ b/eng/linux/BinaryTarBall/package.sh
@@ -1,26 +1,13 @@
 #!/usr/bin/env bash
 
-PKG_FILE="${OTD_LNAME}-${OTD_VERSION}-x64.tar.gz"
+PREFIX="usr/local"
 
 output="${1}"
 
-move_to_nested "${output}" "${output}/build"
+. "${GENERIC_FILES}/package.sh" "${output}"
 
-env PREFIX="/usr/local" "${GENERIC_FILES}/package.sh" "${output}"
-mkdir -p "${output}/usr/local/lib"
-mv "${output}/build" "${output}/usr/local/lib/opentabletdriver"
-
-echo "Patching wrapper scripts to point to '/usr/local/lib/opentabletdriver'..."
-for exe in "${output}/usr/local/bin"/*; do
-  sed -i "s|/usr/lib|/usr/local/lib|" "${exe}"
-done
-
-mkdir -p "${output}/etc/udev/rules.d/"
-mv "${output}/usr/local/lib/udev/rules.d/90-opentabletdriver.rules" "${output}/etc/udev/rules.d/90-opentabletdriver.rules"
-rm -r "${output}/usr/local/lib/udev/"
-sed -i "s|/usr/share|/usr/local/share|" "${output}/usr/local/share/applications/opentabletdriver.desktop"
+PKG_FILE="${OTD_LNAME}-${OTD_VERSION}-x64.tar.gz"
 
 echo "Creating binary tarball '${output}/${PKG_FILE}'..."
-
-move_to_nested "${output}" "${output}/${OTD_LNAME}"
+mv "${output}/files" "${output}/${OTD_LNAME}"
 create_binary_tarball "${output}/${OTD_LNAME}" "${output}/${PKG_FILE}"

--- a/eng/linux/Debian/debian/rules
+++ b/eng/linux/Debian/debian/rules
@@ -5,9 +5,11 @@ SHELL=/usr/bin/env bash
 	dh $@
 
 override_dh_auto_build:
-	./build.sh
+	./eng/linux/package.sh --output bin
 
 override_dh_auto_install:
-	PREFIX=/usr ./eng/linux/Generic/package.sh debian/tmp
+	PREFIX=usr ./eng/linux/package.sh --package Generic --build false
+	mv ./dist/files debian/tmp
+    rm -rf ./dist
 	mkdir -p debian/tmp/usr/lib/
 	cp -r bin debian/tmp/usr/lib/opentabletdriver

--- a/eng/linux/Generic/package.sh
+++ b/eng/linux/Generic/package.sh
@@ -1,18 +1,39 @@
 #!/usr/bin/env bash
 
-. "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
-
 # This is a generic packaging script intended to be used by package maintainers
 
+PKG_FILE="files"
 output="$(readlink -f "${1}")"
-PREFIX="${PREFIX:-/usr/local/}"
+PREFIX="${PREFIX:-usr}"
 
-mkdir -p "${output}/${PREFIX}"
+if ["${BUILD}" == "true"]; then
+  move_to_nested "${output}" "${output}/${PREFIX}/lib/opentabletdriver"
+else
+  mkdir -p "${output}/${PREFIX}"
+fi
+
 copy_generic_files "${output}/${PREFIX}"
 mkdir -p "${output}/${PREFIX}/share/doc/opentabletdriver"
 cp -v "${REPO_ROOT}/LICENSE" "${output}/${PREFIX}/share/doc/opentabletdriver/LICENSE"
 
-generate_rules "${output}/${PREFIX}/lib/udev/rules.d/90-opentabletdriver.rules"
-generate_desktop_file "${output}/${PREFIX}/share/applications/opentabletdriver.desktop"
 copy_pixmap_assets "${output}/${PREFIX}/share/pixmaps"
 copy_manpage "${output}/${PREFIX}/share/man"
+
+if [ "${PREFIX}" == "usr" ]; then
+  generate_rules "${output}/usr/lib/udev/rules.d/90-opentabletdriver.rules"
+else
+  generate_rules "${output}/etc/udev/rules.d/90-opentabletdriver.rules"
+fi
+
+generate_desktop_file "${output}/${PREFIX}/share/applications/opentabletdriver.desktop"
+
+if [ "${PREFIX}" != "usr" ]; then
+  echo "Patching wrapper scripts to point to '/${PREFIX}/bin/opentabletdriver'..."
+  for exe in "${output}/${PREFIX}/bin"/*; do
+    sed -i "s|/usr/lib|/${PREFIX}/lib|" "${exe}"
+  done
+
+  sed -i "s|/usr/share|/${PREFIX}/share|" "${output}/${PREFIX}/share/applications/opentabletdriver.desktop"
+fi
+
+move_to_nested "${output}" "${output}/files"

--- a/eng/linux/RedHat/package.sh
+++ b/eng/linux/RedHat/package.sh
@@ -55,11 +55,13 @@ ${OTD_LONG_DESC2}
 %autosetup
 
 %build
-./build.sh
+./eng/linux/package.sh --output bin
 
 %install
 export DONT_STRIP=1
-PREFIX="%{_prefix}" ./eng/linux/Generic/package.sh "%{buildroot}"
+PREFIX="%{_prefix}" ./eng/linux/package.sh --package Generic --build false
+mv ./dist/files "%{buildroot}"
+rm -rf ./dist
 mkdir -p "%{buildroot}/%{_prefix}/lib/"
 cp -r bin "%{buildroot}/%{_prefix}/lib/opentabletdriver"
 

--- a/eng/linux/lib.sh
+++ b/eng/linux/lib.sh
@@ -19,13 +19,14 @@ copy_generic_files() {
 
   echo "Copying generic files..."
   cp -Rv "${GENERIC_FILES}/usr/"* "${output}"
+  echo
 }
 
 generate_rules() {
   local output_file="${1}"
 
-  echo "Generating udev rules..."
-  "${REPO_ROOT}/generate-rules.sh" -v "${REPO_ROOT}/OpenTabletDriver.Configurations/Configurations" "${output_file}"
+  echo "Generating udev rules to ${output_file}..."
+  "${REPO_ROOT}/generate-rules.sh" "${REPO_ROOT}/OpenTabletDriver.Configurations/Configurations" "${output_file}" > /dev/null
 }
 
 generate_desktop_file() {


### PR DESCRIPTION
This also prevents arch packages from breaking since it uses `./eng/linux/package.sh --package Generic` as a starting point (as intended).